### PR TITLE
Update Migration + Fix SQLSTATE

### DIFF
--- a/src/Greggilbert/Redoubt/GroupObjectPermission/EloquentProvider.php
+++ b/src/Greggilbert/Redoubt/GroupObjectPermission/EloquentProvider.php
@@ -73,7 +73,12 @@ class EloquentProvider implements ProviderInterface
 		{
 			$ids[] = $group->id;
 		}
-				
+			
+		if(empty($ids))
+		{
+			return $ids;
+		}
+		
 		return $this->model->whereIn('group_id', $ids)
 				->get();
 	}

--- a/src/Greggilbert/Redoubt/GroupObjectPermission/EloquentProvider.php
+++ b/src/Greggilbert/Redoubt/GroupObjectPermission/EloquentProvider.php
@@ -32,6 +32,8 @@ class EloquentProvider implements ProviderInterface
 		if(!empty($ids))
 		{
 			$select->whereIn('group_id', $ids);
+		}else{
+			$select->where('group_id', null);
 		}
 		
 		if(!is_null($objectType))

--- a/src/migrations/2013_09_14_121504_create_tables.php
+++ b/src/migrations/2013_09_14_121504_create_tables.php
@@ -17,32 +17,35 @@ class CreateTables extends Migration {
 			$table->string('name', 255)->index();
 		});
 		
-		Schema::create('group_object_permission', function($table)
-		{
-			$table->increments('id');
-			$table->integer('group_id')->index();
-			$table->string('object_type', 255);
-			$table->integer('object_id');
-			$table->integer('permission_id')->index();
-			
-			$table->index(array('object_type', 'object_id'));
-		});
-		
-		Schema::create('group_user', function($table)
-		{
-			$table->increments('id');
-			$table->integer('group_id');
-			$table->integer('user_id');
-			
-			$table->index(array('group_id', 'user_id'));
-		});
-		
 		Schema::create('permissions', function($table)
 		{
 			$table->increments('id');
 			$table->string('name', 255)->index();
 			$table->string('object_type', 255)->index();
 			$table->string('codename', 255)->index();
+		});
+
+		Schema::create('group_object_permission', function($table)
+		{
+			$table->increments('id');
+			$table->integer('group_id')->unsigned()->index();
+			$table->string('object_type', 255);
+			$table->integer('object_id');
+			$table->integer('permission_id')->unsigned()->index();
+			
+			$table->index(array('object_type', 'object_id'));
+			$table->foreign('group_id')->references('id')->on('groups');
+			$table->foreign('permission_id')->references('id')->on('permissions');
+		});
+		
+		Schema::create('group_user', function($table)
+		{
+			$table->increments('id');
+			$table->integer('group_id')->unsigned();
+			$table->integer('user_id');
+			
+			$table->index(array('group_id', 'user_id'));
+			$table->foreign('group_id')->references('id')->on('groups');
 		});
 		
 		Schema::create('user_object_permission', function($table)
@@ -51,9 +54,10 @@ class CreateTables extends Migration {
 			$table->integer('user_id')->index();
 			$table->string('object_type', 255);
 			$table->integer('object_id');
-			$table->integer('permission_id')->index();
+			$table->integer('permission_id')->unsigned()->index();
 			
 			$table->index(array('object_type', 'object_id'));
+			$table->foreign('permission_id')->references('id')->on('permissions');
 		});
 		
 	}


### PR DESCRIPTION
1) Added foreign keys for a better database consistency.

2) Fixed - If you have a user without any permission and you try to do a  "Redoubt::getPermissions($user)" you will get an SQLSTATE.

"SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 (SQL: select \* from `group_object_permission` where `group_id` in ()) (Bindings: array ( ))"
# 

<h4>Improvements</h4>
- It would be nice to add some Unit Testing.
# 

You did a great job ;) Really useful repo !
